### PR TITLE
Upgrade kotlin=1.19.10 java=17 gradle=8.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up JDK 1.11
+      - name: Set up JDK 1.17
         uses: actions/setup-java@v1
         with:
-          java-version: 1.11
+          java-version: 1.17
 
       - name: Build with Gradle
         run: ./tools/scripts/buildWithE2e.sh

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,6 @@ subprojects {
     }
 
     repositories {
-        jcenter()
         mavenCentral()
         mavenLocal()
     }
@@ -42,7 +41,7 @@ subprojects {
     detekt {
         config = files("$parentProjectDir/tools/detekt/detekt-config.yml")
         buildUponDefaultConfig = true
-        input = files("src/main/kotlin", "src/test/kotlin", "src/test/gatling")
+        source = files("src/main/kotlin", "src/test/kotlin", "src/test/gatling")
 
         reports {
             html.enabled = true
@@ -123,15 +122,15 @@ subprojects {
 
         withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
             kotlinOptions {
-                jvmTarget = "1.8"
-                jvmTarget = JavaVersion.VERSION_11.toString()
+                jvmTarget = JavaVersion.VERSION_17.toString()
                 allWarningsAsErrors = failOnWarning
-                freeCompilerArgs = listOf("-Xjvm-default=enable")
+                freeCompilerArgs = listOf("-Xjvm-default=all-compatibility")
             }
         }
 
         withType<JavaCompile> {
             options.compilerArgs.add("-Xlint:all")
+            targetCompatibility = JavaVersion.VERSION_17.toString()
         }
 
         withType<Test> {

--- a/buildSrc/src/main/kotlin/Global.kt
+++ b/buildSrc/src/main/kotlin/Global.kt
@@ -1,3 +1,3 @@
 object Global {
-    const val kotlin_version = "1.6.0"
+    const val kotlin_version = "1.9.10"
 }

--- a/buildSrc/src/main/kotlin/ProjectDependencies.kt
+++ b/buildSrc/src/main/kotlin/ProjectDependencies.kt
@@ -21,7 +21,7 @@ object LibVers {
     const val resilience4j_circuitbreaker = "1.7.1"
     const val resilience4j_bulkhead = "1.7.1"
     const val kbdd = "1.1.1"
-    const val koin = "2.0.1"
+    const val koin = "3.5.0"
     const val rest_assured = "4.4.0"
     const val corounit = "1.1.1"
     const val spring_rabbit_test = "2.4.0"
@@ -76,7 +76,7 @@ object Libs {
     const val testcontainers_core = "org.testcontainers:testcontainers:${LibVers.testcontainers}"
     const val wiremock = "com.github.tomakehurst:wiremock-jre8:${LibVers.wiremock}"
     const val kbdd = "ru.fix:kbdd:${LibVers.kbdd}"
-    const val koin = "org.koin:koin-core:${LibVers.koin}"
+    const val koin = "io.insert-koin:koin-core:${LibVers.koin}"
     const val rest_assured = "io.rest-assured:rest-assured:${LibVers.rest_assured}"
     const val rest_assured_kotlin = "io.rest-assured:kotlin-extensions:${LibVers.rest_assured}"
     const val spring_rabbit_test = "org.springframework.amqp:spring-rabbit-test:${LibVers.spring_rabbit_test}"
@@ -108,7 +108,7 @@ object Libs {
 object PluginVers {
     const val kotlin = Global.kotlin_version
     const val spring_boot = LibVers.spring_boot
-    const val detekt = "1.19.0"
+    const val detekt = "1.23.3"
     const val detekt_formatting = detekt
     const val spring_dependency_management = "1.0.11.RELEASE"
     const val spring_kotlin = Global.kotlin_version
@@ -118,7 +118,7 @@ object PluginVers {
     const val allure = "2.9.6"
     const val allure_cli = "2.15.0"
     const val allure_java = "2.15.0"
-    const val gatling = "3.7.2"
+    const val gatling = "3.9.5.6"
 }
 
 object Plugins {

--- a/common/types/src/main/kotlin/com/stringconcat/ddd/common/types/base/AggregateRoot.kt
+++ b/common/types/src/main/kotlin/com/stringconcat/ddd/common/types/base/AggregateRoot.kt
@@ -1,3 +1,4 @@
 package com.stringconcat.ddd.common.types.base
 
+@Suppress("UnnecessaryAbstractClass")
 abstract class AggregateRoot<T>(id: T, version: Version) : DomainEntity<T>(id, version)

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kitchen/application/build.gradle.kts
+++ b/kitchen/application/build.gradle.kts
@@ -76,3 +76,7 @@ dependencies {
     testFixturesImplementation(Libs.spring_boot_starter_amqp)
 
 }
+
+tasks.build {
+    dependsOn("bootJar")
+}

--- a/shop/application/build.gradle.kts
+++ b/shop/application/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
 project.base.archivesName.set("shop-application")
 
 plugins {
@@ -87,4 +89,8 @@ dependencies {
     testFixturesImplementation(Libs.spring_boot_starter_web)
     testFixturesImplementation(Libs.spring_boot_starter_amqp)
 
+}
+
+tasks.build {
+    dependsOn("bootJar")
 }

--- a/tests/e2e/src/test/kotlin/com/stringconcat/ddd/e2e/cases/OrderAndCookCase.kt
+++ b/tests/e2e/src/test/kotlin/com/stringconcat/ddd/e2e/cases/OrderAndCookCase.kt
@@ -20,8 +20,8 @@ import com.stringconcat.ddd.tests.common.StandConfiguration
 import io.qameta.allure.Epic
 import io.qameta.allure.Story
 import org.junit.jupiter.api.Test
-import org.koin.core.KoinComponent
-import org.koin.core.inject
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 import ru.fix.corounit.allure.invoke
 import ru.fix.corounit.allure.repeatUntilSuccess
 

--- a/tests/e2e/src/test/kotlin/com/stringconcat/ddd/e2e/steps/CartSteps.kt
+++ b/tests/e2e/src/test/kotlin/com/stringconcat/ddd/e2e/steps/CartSteps.kt
@@ -5,7 +5,7 @@ import com.stringconcat.ddd.e2e.MealId
 import com.stringconcat.ddd.e2e.OrderId
 import com.stringconcat.ddd.e2e.Url
 import io.kotest.matchers.shouldBe
-import org.koin.core.KoinComponent
+import org.koin.core.component.KoinComponent
 import ru.fix.corounit.allure.Step
 import ru.fix.kbdd.asserts.asString
 import ru.fix.kbdd.asserts.isContains

--- a/tests/e2e/src/test/kotlin/com/stringconcat/ddd/e2e/steps/CrmSteps.kt
+++ b/tests/e2e/src/test/kotlin/com/stringconcat/ddd/e2e/steps/CrmSteps.kt
@@ -3,8 +3,8 @@ package com.stringconcat.ddd.e2e.steps
 import com.stringconcat.ddd.e2e.ID
 import com.stringconcat.ddd.e2e.OrderId
 import com.stringconcat.ddd.tests.common.StandConfiguration
-import org.koin.core.KoinComponent
-import org.koin.core.inject
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 import ru.fix.corounit.allure.Step
 import ru.fix.kbdd.asserts.get
 import ru.fix.kbdd.asserts.isEquals

--- a/tests/e2e/src/test/kotlin/com/stringconcat/ddd/e2e/steps/MenuSteps.kt
+++ b/tests/e2e/src/test/kotlin/com/stringconcat/ddd/e2e/steps/MenuSteps.kt
@@ -7,7 +7,7 @@ import com.stringconcat.ddd.e2e.mealName
 import com.stringconcat.ddd.e2e.price
 import io.kotest.matchers.shouldBe
 import org.apache.http.HttpHeaders
-import org.koin.core.KoinComponent
+import org.koin.core.component.KoinComponent
 import ru.fix.corounit.allure.Step
 import ru.fix.kbdd.asserts.asString
 import ru.fix.kbdd.asserts.get

--- a/tests/e2e/src/test/kotlin/com/stringconcat/ddd/e2e/steps/OrderSteps.kt
+++ b/tests/e2e/src/test/kotlin/com/stringconcat/ddd/e2e/steps/OrderSteps.kt
@@ -1,7 +1,7 @@
 package com.stringconcat.ddd.e2e.steps
 
 import com.stringconcat.ddd.e2e.Url
-import org.koin.core.KoinComponent
+import org.koin.core.component.KoinComponent
 import ru.fix.corounit.allure.Step
 import ru.fix.kbdd.asserts.isEquals
 import ru.fix.kbdd.rest.Rest

--- a/tests/e2e/src/test/kotlin/com/stringconcat/ddd/e2e/steps/UrlSteps.kt
+++ b/tests/e2e/src/test/kotlin/com/stringconcat/ddd/e2e/steps/UrlSteps.kt
@@ -9,7 +9,7 @@ import com.stringconcat.ddd.e2e.OrderId
 import com.stringconcat.ddd.e2e.SELF
 import com.stringconcat.ddd.e2e.Url
 import io.kotest.matchers.shouldBe
-import org.koin.core.KoinComponent
+import org.koin.core.component.KoinComponent
 import ru.fix.corounit.allure.Step
 import ru.fix.kbdd.asserts.asString
 import ru.fix.kbdd.asserts.filter

--- a/tests/mock-server/build.gradle.kts
+++ b/tests/mock-server/build.gradle.kts
@@ -30,6 +30,10 @@ dependencies {
     }
 }
 
+tasks.build {
+    dependsOn("bootJar")
+}
+
 tasks.register<Copy>("copyPacts") {
     val srcDir = "${rootProject.buildDir}/pacts"
     val destDir = "${project.buildDir}/pacts"

--- a/tools/detekt/detekt-config.yml
+++ b/tools/detekt/detekt-config.yml
@@ -1,6 +1,8 @@
 style:
   NewLineAtEndOfFile:
     active: false
+  ExplicitItLambdaParameter:
+    active: false
 
 
 complexity:
@@ -17,6 +19,18 @@ formatting:
     active: false
   ImportOrdering:
     active: false
+  Wrapping:
+    active: false
+  ArgumentListWrapping:
+    active: false
+  NoEmptyFirstLineInMethodBlock:
+    active: false
+
+
+naming:
+  VariableNaming:
+    active: false
+
 
 performance:
   SpreadOperator:


### PR DESCRIPTION
Upgrades kotlin, java, and gradle versions.
- Kotlin 1.9.10 — latest stable major release supported by the ecosystem
- java 17 — latest stable LTS major release supported by the ecosystem
- Gradle — (_first rule of gradle — never talk about gradle stability_) the latest release

Does only the necessary upgrades to the dependencies:
- detekt - support for new kotlin - added sensible defaults for the new rules
- koin - support for new kotlin 
- gatling - support for new java 